### PR TITLE
Multiple updates in order to match current upstream

### DIFF
--- a/snap/.snapcraft/state
+++ b/snap/.snapcraft/state
@@ -1,0 +1,4 @@
+!GlobalState
+assets:
+  build-packages: []
+  build-snaps: []

--- a/snap/.snapcraft/state
+++ b/snap/.snapcraft/state
@@ -1,4 +1,0 @@
-!GlobalState
-assets:
-  build-packages: []
-  build-snaps: []

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ parts:
     after: [desktop-glib-only]
     source: https://github.com/scummvm/scummvm.git
     override-build: |
-      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag="$(git tag --list | tac | head -n1)"
       trimmed_tag="$(echo $last_committed_tag | sed 's/desc\///' | sed 's/git//' )"
       last_released_tag="$(snap info scummvm | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
@@ -31,7 +31,7 @@ parts:
         git checkout "${last_committed_tag}"
       fi    
       snapcraftctl build
-      snapcraftctl set-version $(git -C ../src describe --tags | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
+      snapcraftctl set-version $(git -C ../src tag --list | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
     plugin: autotools
     configflags:
       - --enable-release

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ grade: stable
 apps:
   scummvm:
     command: desktop-launch $SNAP/bin/scummvm
-    plugs: [x11, home, pulseaudio, unity7, opengl]
+    plugs: [x11, home, pulseaudio, unity7, opengl, network]
 
 parts:
   scummvm:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ grade: stable
 apps:
   scummvm:
     command: desktop-launch $SNAP/bin/scummvm
-    plugs: [x11, home, pulseaudio, unity7, opengl, network]
+    plugs: [x11, home, pulseaudio, audio-playback, unity7, opengl, network]
 
 parts:
   scummvm:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ grade: stable
 apps:
   scummvm:
     command: desktop-launch $SNAP/bin/scummvm
-    plugs: [x11, home, pulseaudio, audio-playback, unity7, opengl, network]
+    plugs: [x11, home, pulseaudio, audio-playback, unity7, opengl, network, removable-media]
 
 parts:
   scummvm:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,10 +33,15 @@ parts:
       snapcraftctl build
       snapcraftctl set-version $(git -C ../src describe --tags | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
     plugin: autotools
+    configflags:
+      - --enable-release
+      - --disable-debug
+
 #    To do a quick test build
 #    configflags:
 #      - --disable-all-engines
 #      - --enable-engine=scumm
+
     build-packages:
       - g++
       - make

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,8 @@ parts:
       - libfreetype6-dev
       - zlib1g-dev
       - libunity-dev
+      - libcurl4-openssl-dev
+      - libsdl2-net-dev
     stage-packages:
       - libicu60
       - libasound2
@@ -82,6 +84,9 @@ parts:
       - libunity-protocol-private0
       - libunity9
       - freeglut3
+      - libcurl4
+      - libsdl2-net-2.0-0
+      - liba52-0.7.4
 
   desktop-glib-only:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git


### PR DESCRIPTION
This adds libsdl2 and libcurl to the list of the libraries that should be included in the snap package. Both libs are necessary in order to use the cloud features we introduced in the previous release.

Slightly unrelated, I added liba52 to the stage-packages since I got a warning from snapcraft that including libraries "implicitly" might be removed in the future, so better to be safe than sorry. In case this is not the correct way to solve the warning, please just let me know so I can fix this commit.