### PR TITLE
Add missing network-bind plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,7 +14,7 @@ grade: stable
 apps:
   scummvm:
     command: desktop-launch $SNAP/bin/scummvm
-    plugs: [x11, home, pulseaudio, audio-playback, unity7, opengl, network, removable-media]
+    plugs: [x11, home, pulseaudio, audio-playback, unity7, opengl, network, network-bind, removable-media]
 
 parts:
   scummvm:


### PR DESCRIPTION
This plug is necessary to run the local webserver within ScummVM
in order to provide the local file sharing service.