### PR TITLE
Fix version detection for trimmed_tag

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,16 +22,19 @@ parts:
     source: https://github.com/scummvm/scummvm.git
     override-build: |
       last_committed_tag="$(git tag --list | tac | head -n1)"
-      trimmed_tag="$(echo $last_committed_tag | sed 's/desc\///' | sed 's/git//' )"
+      trimmed_tag="$(echo $last_committed_tag | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')"
       last_released_tag="$(snap info scummvm | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
       # beta, build that tag instead of master.
       if [ "${trimmed_tag}" != "${last_released_tag}" ]; then
         git fetch
         git checkout "${last_committed_tag}"
+        snapcraftctl set-version $(git -C ../src tag --list | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
+      else
+        snapcraftctl set-version $(git -C ../src describe | sed 's/desc\///')
       fi    
       snapcraftctl build
-      snapcraftctl set-version $(git -C ../src tag --list | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
+      
     plugin: autotools
     configflags:
       - --enable-release


### PR DESCRIPTION
Previously (most likely introduced in ec8ae260241479f233f48b6930daa66953b434df), the `trimmed_tag` and `last_released_tag` always mismatched:

```
trimmed_tag = v2.1.1
last_released_tag = 2.1.1
```

Therefore, the check if we should build the last released tag or the current master branch always failed. This patch fixes this behaviour by stripping the leading 'v' from the last released tag.

Furthermore, I now set a different snap package version if we build from master to make it easier for us to debug issues with the nightlies from master.