### PR TITLE
Get ready for release 🎉

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
   scummvm:
     command-chain: ["snap/command-chain/alsa-launch"]
     command: desktop-launch $SNAP/bin/scummvm
-    plugs: [x11, home, alsa, audio-playback, unity7, opengl, network, network-bind, removable-media]
+    plugs: [x11, wayland, home, alsa, audio-playback, unity7, opengl, network, network-bind, removable-media]
 
 parts:
   scummvm:
@@ -83,6 +83,8 @@ parts:
       - libfluidsynth1
       - libgl1-mesa-dri
       - libgl1-mesa-glx
+      - libglu1-mesa
+      - libwayland-egl1-mesa
       - libjpeg62
       - libjpeg8
       - libmad0
@@ -98,7 +100,6 @@ parts:
       - zlib1g
       - libdbusmenu-glib4
       - libdee-1.0-4
-      - libglu1-mesa
       - libslang2
       - libunity-protocol-private0
       - libunity9

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,6 +49,7 @@ parts:
     plugin: autotools
     configflags:
       - --enable-release
+      - --enable-opl2lpt
       - --disable-debug
 
 #    To do a quick test build
@@ -76,6 +77,7 @@ parts:
       - libunity-dev
       - libcurl4-openssl-dev
       - libsdl2-net-dev
+      - libieee1284-3-dev
     stage-packages:
       - libicu60
       - libfaad2
@@ -107,6 +109,7 @@ parts:
       - libcurl4
       - libsdl2-net-2.0-0
       - liba52-0.7.4
+      - libieee1284-3
       - locales-all
 
   alsa-mixin:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,16 +23,19 @@ parts:
     source: https://github.com/scummvm/scummvm.git
     override-build: |
       last_committed_tag="$(git tag --list | tac | head -n1)"
-      trimmed_tag="$(echo $last_committed_tag | sed 's/desc\///' | sed 's/git//' )"
+      trimmed_tag="$(echo $last_committed_tag | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')"
       last_released_tag="$(snap info scummvm | awk '$1 == "beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
       # beta, build that tag instead of master.
       if [ "${trimmed_tag}" != "${last_released_tag}" ]; then
         git fetch
         git checkout "${last_committed_tag}"
+        snapcraftctl set-version $(git -C ../src tag --list | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
+      else
+        snapcraftctl set-version $(git -C ../src describe | sed 's/desc\///')
       fi    
       snapcraftctl build
-      snapcraftctl set-version $(git -C ../src tag --list | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
+      
     plugin: autotools
     configflags:
       - --enable-release

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,7 @@ parts:
       - libsdl2-dev
       - libjpeg62-dev
       - libmpeg2-4-dev
+      - liba52-dev
       - libogg-dev
       - libvorbis-dev
       - libflac-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,17 @@ apps:
   scummvm:
     command-chain: ["snap/command-chain/alsa-launch"]
     command: desktop-launch $SNAP/bin/scummvm
-    plugs: [x11, wayland, home, alsa, audio-playback, unity7, opengl, network, network-bind, removable-media]
+    plugs:
+      - x11
+      - wayland
+      - unity7
+      - opengl
+      - alsa
+      - audio-playback
+      - home
+      - network
+      - network-bind
+      - removable-media
 
 parts:
   scummvm:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,7 +67,6 @@ parts:
       - libsdl2-net-dev
     stage-packages:
       - libicu60
-      - libasound2
       - libfaad2
       - libflac8
       - libfluidsynth1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: scummvm
 base: core18
+license: GPL-2.0
 adopt-info: scummvm
 summary: ScummVM
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,15 @@ description: |
     files. The clever part about this: ScummVM just replaces the executables
     shipped with the game, allowing you to play them on systems for which
     they were never designed!
+
+    Currently, ScummVM supports a huge library of adventures with over
+    250 games in total.
+    
+    It supports many classics published by legendary studios like LucasArts,
+    Sierra On-Line, Revolution Software, Cyan, Inc. and Westwood Studios.
+    Next to ground-breaking titles like the Monkey Island series,
+    Broken Sword, Myst, Blade Runner and countless other games,
+    you will find some really obscure adventures and truly hidden gems to explore.
 confinement: strict
 grade: stable
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,7 @@ parts:
       - libcurl4
       - libsdl2-net-2.0-0
       - liba52-0.7.4
+      - locales-all
 
   alsa-mixin:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
   scummvm:
     command-chain: ["snap/command-chain/alsa-launch"]
     command: desktop-launch $SNAP/bin/scummvm
-    plugs: [x11, home, alsa, pulseaudio, audio-playback, unity7, opengl, network, network-bind, removable-media]
+    plugs: [x11, home, alsa, audio-playback, unity7, opengl, network, network-bind, removable-media]
 
 parts:
   scummvm:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,12 +13,13 @@ grade: stable
 
 apps:
   scummvm:
+    command-chain: ["snap/command-chain/alsa-launch"]
     command: desktop-launch $SNAP/bin/scummvm
-    plugs: [x11, home, pulseaudio, audio-playback, unity7, opengl, network, network-bind, removable-media]
+    plugs: [x11, home, alsa, pulseaudio, audio-playback, unity7, opengl, network, network-bind, removable-media]
 
 parts:
   scummvm:
-    after: [desktop-glib-only]
+    after: [alsa-mixin, desktop-glib-only]
     source: https://github.com/scummvm/scummvm.git
     override-build: |
       last_committed_tag="$(git tag --list | tac | head -n1)"
@@ -92,6 +93,63 @@ parts:
       - libcurl4
       - libsdl2-net-2.0-0
       - liba52-0.7.4
+
+  alsa-mixin:
+    plugin: nil
+    source: https://github.com/diddlesnaps/snapcraft-alsa.git
+    override-pull: |
+      cat > asound.conf <<EOF
+      pcm.!default {
+          type pulse
+          fallback "sysdefault"
+          hint {
+              show on
+              description "Default ALSA Output (currently PulseAudio Sound Server)"
+          }
+      }
+      ctl.!default {
+          type pulse
+          fallback "sysdefault"
+      }
+      seq.default {
+          type hw
+      }
+      seq.hw {
+          type hw
+      }
+      EOF
+      cat > alsa-launch <<EOF
+      #!/bin/bash
+      export ALSA_CONFIG_PATH="\$SNAP/etc/asound.conf"
+
+      if [ -d "\$SNAP/usr/lib/alsa-lib" ]; then
+          export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:\$SNAP/usr/lib/alsa-lib"
+      elif [ -d "\$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib" ]; then
+          export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:\$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib"
+      fi
+      export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:\$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
+
+      # Make PulseAudio socket available inside the snap-specific \$XDG_RUNTIME_DIR
+      if [ -n "\$XDG_RUNTIME_DIR" ]; then
+          pulsenative="pulse/native"
+          pulseaudio_sockpath="\$XDG_RUNTIME_DIR/../\$pulsenative"
+          if [ -S "\$pulseaudio_sockpath" ]; then
+              export PULSE_SERVER="unix:\${pulseaudio_sockpath}"
+          fi
+      fi
+
+      exec "\$@"
+      EOF
+      chmod +x alsa-launch
+    override-build: |
+      snapcraftctl build
+      install -m644 -D -t $SNAPCRAFT_PART_INSTALL/etc asound.conf
+      install -m755 -D -t $SNAPCRAFT_PART_INSTALL/snap/command-chain alsa-launch
+    build-packages:
+      - libasound2-dev
+    stage-packages:
+      - libasound2
+      - libasound2-plugins
 
   desktop-glib-only:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git


### PR DESCRIPTION
This PR includes (almost) everything to make the Snap Package 'as good as' the official ScummVM 2.1.1 release. It includes the following changes and improvements:

- Fixing the version detection since currently, the check if `master` should be built always fails
- Adding support for the ALSA features we use (requires `alsa` plug - auto-connect maybe? 😎)
- Adding support for translation detection by adding `locales-all`
- Adding support for `liba52`
- Adding support for the OPL2LPT extension
- Adding support for `wayland` - lot entirely sure if it's using `XWayland` or not. Needs testing...
- Package cleanup
- Updating the Snap Package description and adding license information

Now the only thing that's left is TTS support via `libspeechd/speech-dispatcher`, but this will take some time and research.

Thanks @popey for your support and encouragement :)