### PR TITLE
Add drascula-music .deb file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -234,3 +234,7 @@ parts:
   drascula:
     plugin: dump
     source: http://archive.ubuntu.com/ubuntu/pool/universe/d/drascula/drascula_1.0+ds4-1_all.deb
+
+  drascula-music:
+    plugin: dump
+    source: http://archive.ubuntu.com/ubuntu/pool/universe/d/drascula/drascula-music_1.0+ds4-1_all.deb


### PR DESCRIPTION
This provides the (currently missing) background music for drascula.

Since the drascula-music package depends on the drascula package itself,
I decided to pull it in the manual way in order to avoid conflicts with
the datafile music.

If there's a way to pull in multiple .deb files via the source plugin, let me know.