### PR TITLE
Ship a games bundle with ScummVM

### DIFF
--- a/scripts/bin/scummvm-launch.sh
+++ b/scripts/bin/scummvm-launch.sh
@@ -16,13 +16,17 @@ $SNAP/usr/bin/speech-dispatcher -d -C "$SNAP/etc/speech-dispatcher" -S "$XDG_RUN
 
 # We need to do this for the user that launches scummvm, so
 # it can't be done on installation
-while [ ! -f "${XDG_CONFIG_HOME}/scummvm/scummvm.ini" ]
+while [ ! -f "${XDG_CONFIG_HOME}/scummvm/.added-games-bundle" ]
 do
+  mkdir -p ${XDG_CONFIG_HOME}/scummvm/
+  touch ${XDG_CONFIG_HOME}/scummvm/.added-games-bundle
+  if ! grep -E "comi|drascula|dreamweb|lure|queen|sky|sword" ${XDG_CONFIG_HOME}/scummvm/scummvm.ini
+  then
   # Register the bundled games. We use a "while" loop as we can't easily
   # tell when scummvm is finished.
-  mkdir -p ${XDG_CONFIG_HOME}
-  $SNAP/bin/scummvm  -p /usr/share/scummvm/ --recursive --add
+  $SNAP/bin/scummvm -p /usr/share/scummvm/ --recursive --add
   sleep 1
+  fi
 done
 
 exec $SNAP/bin/scummvm "$@"

--- a/scripts/bin/scummvm-launch.sh
+++ b/scripts/bin/scummvm-launch.sh
@@ -20,7 +20,7 @@ while [ ! -f "${XDG_CONFIG_HOME}/scummvm/.added-games-bundle" ]
 do
   mkdir -p ${XDG_CONFIG_HOME}/scummvm/
   touch ${XDG_CONFIG_HOME}/scummvm/.added-games-bundle
-  if ! grep -E "comi|drascula|dreamweb|lure|queen|sky|sword" ${XDG_CONFIG_HOME}/scummvm/scummvm.ini
+  if ! grep -E "comi|drascula|dreamweb|lure|myst|queen|sky|sword" ${XDG_CONFIG_HOME}/scummvm/scummvm.ini
   then
   # Register the bundled games. We use a "while" loop as we can't easily
   # tell when scummvm is finished.

--- a/snap/gui/scummvm.desktop
+++ b/snap/gui/scummvm.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Name=ScummVM
-Comment=Interpreter for several adventure games
+Comment=Interpreter for numerous adventure games and RPGs
 Comment[pl]=Interpreter graficznych gier przygodowych
 Comment[sv]=Tolk för flera äventyrsspel
 Comment[he]=פרשן למספר משחקי הרפתקאות
-Comment[de]=Interpreter für diverse Abenteuerspiele
+Comment[de]=Interpreter für zahlreiche Abenteuerspiele und RPGs
 Comment[es]=Intérprete para varias aventuras gráficas
 Comment[ca]=Intèrpret per diverses aventures gràfiques
 Exec=scummvm

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -227,7 +227,7 @@ parts:
     build-packages:
       - unzip
     override-pull: |
-      wget https://fr1.eu.scummvm.net/extras/games-bundle.zip
+      wget https://www.scummvm.org/frs/extras/games-bundle.zip
     override-build: |
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/scummvm/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -223,17 +223,10 @@ parts:
     source: scripts
 
   games:
-    plugin: nil
-    build-packages:
-      - unzip
-    override-pull: |
-      wget https://www.scummvm.org/frs/extras/games-bundle.zip
+    plugin: dump
+    source: https://www.scummvm.org/frs/extras/games-bundle.zip
+    source-checksum: sha256/5c16f3db7fda3660d1bddb52e76aa27ada8eb8268872f5e045490f3eabb603e1
     override-build: |
       snapcraftctl build
       mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/scummvm/
-
-      if ! echo "5c16f3db7fda3660d1bddb52e76aa27ada8eb8268872f5e045490f3eabb603e1 games-bundle.zip" | sha256sum -c -; then
-        echo "Detected corrupt games-bundle.zip, not including!"
-      else
-        unzip games-bundle.zip -d $SNAPCRAFT_PART_INSTALL/usr/share/scummvm/
-      fi
+      mv $SNAPCRAFT_PART_INSTALL/games-bundle $SNAPCRAFT_PART_INSTALL/usr/share/scummvm/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -226,7 +226,5 @@ parts:
     plugin: dump
     source: https://www.scummvm.org/frs/extras/games-bundle.zip
     source-checksum: sha256/5c16f3db7fda3660d1bddb52e76aa27ada8eb8268872f5e045490f3eabb603e1
-    override-build: |
-      snapcraftctl build
-      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/scummvm/
-      mv $SNAPCRAFT_PART_INSTALL/games-bundle $SNAPCRAFT_PART_INSTALL/usr/share/scummvm/
+    organize:
+      games-bundle: usr/share/scummvm/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -224,13 +224,16 @@ parts:
 
   games:
     plugin: nil
-    stage-packages:
-      - beneath-a-steel-sky
-      - flight-of-the-amazon-queen
-      - lure-of-the-temptress
-      # - drascula "WARNING: Incorrect version of the 'drascula.dat' engine data file found. Expected 5.0 but got 4.0.!"
+    build-packages:
+      - unzip
+    override-pull: |
+      wget https://fr1.eu.scummvm.net/extras/games-bundle.zip
+    override-build: |
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/usr/share/scummvm/
 
-  # drascula from 20.04
-  drascula:
-    plugin: dump
-    source: http://archive.ubuntu.com/ubuntu/pool/universe/d/drascula/drascula_1.0+ds4-1_all.deb
+      if ! echo "5c16f3db7fda3660d1bddb52e76aa27ada8eb8268872f5e045490f3eabb603e1 games-bundle.zip" | sha256sum -c -; then
+        echo "Detected corrupt games-bundle.zip, not including!"
+      else
+        unzip games-bundle.zip -d $SNAPCRAFT_PART_INSTALL/usr/share/scummvm/
+      fi


### PR DESCRIPTION
This patch introduces the usage of a separate games-bundle.zip archive file in order to provide the bundled games. This allows us to pack more/different games and demos inside the snap package without having to rely on what's in the Ubuntu or Debian repos.

To prevent corruption or unaltered tampering with the zip file, its SHA256 checksum is validated before including in the snap. In case of a corrupt download, we simply don't include it and ship a snap package without the games.

I also propose to use a separate file instead of the scummvm.ini file to detect if we already run the gane adding job - with this change, we can now ship the games to already existing installations.

In order to avoid messing with already added games, we only add them if none of the bundled games are already present in the user's installation.