### PR TITLE
Increase timeout for speech-dispatcher to 30 seconds

### DIFF
--- a/scripts/bin/scummvm-launch.sh
+++ b/scripts/bin/scummvm-launch.sh
@@ -12,7 +12,7 @@ fi
 
 # Hook up speech-dispatcher
 mkdir -p $XDG_RUNTIME_DIR/speech-dispatcher
-$SNAP/usr/bin/speech-dispatcher -d -C "$SNAP/etc/speech-dispatcher" -S "$XDG_RUNTIME_DIR/speech-dispatcher/speechd.sock" -m "$SNAP/usr/lib/speech-dispatcher-modules"
+$SNAP/usr/bin/speech-dispatcher -d -C "$SNAP/etc/speech-dispatcher" -S "$XDG_RUNTIME_DIR/speech-dispatcher/speechd.sock" -m "$SNAP/usr/lib/speech-dispatcher-modules" -t 30
 
 # We need to do this for the user that launches scummvm, so
 # it can't be done on installation


### PR DESCRIPTION
By default, speech-dispatcher has a timeout of only a few seconds before it shuts down after receiving no "incoming" connection.

In some edge cases like running the snap for the first time and thus triggering the mass-add feature, this could lead to the speechd daemon shutting down too early and breaking TTS support on the first execution. Even though this could be mitigated via simply restarting ScummVM, this affects the user's experience.

Setting the speech-dispatcher timeout to 30 seconds ensures that speechd is still open for connections, even with the delay added by adding the games.

The only downside of this change is that it may take up to 30 seconds now for the speechd daemon to die after ScummVM is exited - but it will die eventually and run silently in the background until it's time to go.