### PR TITLE
Fix LD_LIBRARY_PATH for daemon execution

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,7 +54,7 @@ apps:
       - pulseaudio
     environment:
       SDL_VIDEODRIVER: wayland
-      LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libunity/:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio/:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/speech-dispatcher/"
+      LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libunity/:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio/:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/speech-dispatcher/"
       ESPEAK_DATA_PATH: "$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/espeak-ng-data"
       PULSE_SYSTEM: 1
       PULSE_RUNTIME_PATH: /var/run/pulse


### PR DESCRIPTION
Missing $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/ means a crash with:
```plain
2020-06-01T08:40:54Z scummvm.daemon[7213]: + exec /snap/scummvm/3860/bin/scummvm -f
2020-06-01T08:40:55Z scummvm.daemon[7213]: /snap/scummvm/3860/bin/scummvm: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory
```