### PR TITLE
Workaround for global plugs not working for daemon

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,7 @@ description: |
 confinement: strict
 grade: stable
 
+# **Workaround** The following are duplicated for "daemon" (putting them at the top level doesn't work in *this* snap)
 plugs:
   wayland:
   opengl:
@@ -52,6 +53,14 @@ apps:
     restart-condition: always
     plugs:
       - pulseaudio
+      # **Workaround** The following are duplicated for "daemon" (putting them at the top level doesn't work in *this* snap)
+      - wayland
+      - opengl
+      - alsa
+      - audio-playback
+      - network
+      - network-bind
+      - removable-media
     environment:
       SDL_VIDEODRIVER: wayland
       LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/libunity/:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/pulseaudio/:$SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/speech-dispatcher/"


### PR DESCRIPTION
Workaround for global plugs not working for daemon. In particular, the wayland interface isn't represented in the AppArmor profile.

_This shouldn't be necessary_, top level plugs work in other snaps, but not for this one. I've not dug into the reasons for this, simply found a workaround.