### PR TITLE
Remove global plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,16 +21,6 @@ description: |
 confinement: strict
 grade: stable
 
-# **Workaround** The following are duplicated for "daemon" (putting them at the top level doesn't work in *this* snap)
-plugs:
-  wayland:
-  opengl:
-  alsa:
-  audio-playback:
-  network:
-  network-bind:
-  removable-media:
-
 apps:
   scummvm:
     command-chain: ["snap/command-chain/alsa-launch"]
@@ -61,7 +51,6 @@ apps:
     restart-condition: always
     plugs:
       - pulseaudio
-      # **Workaround** The following are duplicated for "daemon" (putting them at the top level doesn't work in *this* snap)
       - wayland
       - opengl
       - alsa


### PR DESCRIPTION
Since we need to duplicate the plugs for both the ScummVM app section and the daemon, I'm tempted to get rid of the (obsolete?) global plugs to avoid even more code duplication.

@AlanGriffiths can you please confirm that this patch won't break anything daemon-related?