### PR TITLE
Strip tags to discard platform-specific tags and documentation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -98,21 +98,19 @@ parts:
       - LDFLAGS:  "$LDFLAGS  -fuse-ld=gold -flto=$(nproc) -Wl,--gc-sections"
 
     override-build: |
-      last_committed_tag="$(git tag --list | tac | head -n1)"
+      last_committed_tag="$(git tag --list | sed '/android\|docs/d' | tac | head -n1)"
       trimmed_tag="$(echo $last_committed_tag | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')"
       last_released_tag="$(snap info scummvm | awk '$1 == "latest/beta:" { print $2 }')"
       # If the latest tag from the upstream project has not been released to
       # beta, build that tag instead of master.
-      #if [ "${trimmed_tag}" != "${last_released_tag}" ]; then
+      if [ "${trimmed_tag}" != "${last_released_tag}" ]; then
         git fetch
-        # git checkout -f "${last_committed_tag}"
-        git checkout -f v2.2.0
-        # snapcraftctl set-version $(git -C ../src tag --list | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
-        snapcraftctl set-version 2.2.0
-      #else
-      #  git checkout master
-      #  snapcraftctl set-version $(git describe | sed 's/desc\///')
-      #fi
+        git checkout -f "${last_committed_tag}"
+        snapcraftctl set-version $(git -C ../src tag --list | sed '/android\|docs/d' | tac | head -n1 | sed 's/desc\///' | sed 's/git//' | sed 's/^v//')
+      else
+        git checkout master
+        snapcraftctl set-version $(git describe | sed 's/desc\///')
+      fi
       snapcraftctl build
       strip --strip-all $SNAPCRAFT_PART_INSTALL/bin/scummvm
       


### PR DESCRIPTION
This patch fixes the auto-detection of the tag last released upstream, so we restore the previous behaviour and don't need to do manual version bumps.

This patch is necessary since the introduction of our new documentation portal involves setting new tags (``-docs``), while ``-android`` needs to be removed as well since these are special versions meant for Google Play distribution.