### PR TITLE
limit build architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,10 @@ description: |
 confinement: strict
 grade: stable
 compression: lzo
-
+architectures:
+- build-on: amd64
+- build-on: arm64
+- build-on: armhf
 apps:
   scummvm:
     command-chain:


### PR DESCRIPTION
This snap depends on the gnome extension, which isn't available for ppcel64 or s390x, so let's prevent even trying to build on those architectures. 

e.g.  from [this build](https://launchpadlibrarian.net/690909381/buildlog_snap_ubuntu_focal_ppc64el_f575d29e94f650a871d01c059930838d_BUILDING.txt.gz)
```
Failed to install or refresh a snap: 'gnome-3-38-2004-sdk' does not exist or is not available on the desired channel 'latest/stable'. Use `snap info gnome-3-38-2004-sdk` to get a list of channels the snap is available on.
```